### PR TITLE
Catch unhandled errors when loading a resource from a URL

### DIFF
--- a/ckanext/opendatani/controller.py
+++ b/ckanext/opendatani/controller.py
@@ -246,11 +246,15 @@ class CustomPackageController(CorePackageController):
                 'dataset_type': dataset_type}
         print MAX_FILE_SIZE
         if c.resource['url_type'] != 'upload':
-            r = requests.head(c.resource['url'])
-            if r.status_code not in (400, 403, 405) and r.ok:
-                size = r.headers.get('content-length')
-                if size and int(size) > MAX_FILE_SIZE:
-                    h.flash_error('Sorry, this file is too large to be able to display in the browser, please download the data resource to examine it further.')
+            try:
+                r = requests.head(c.resource['url'])
+                if r.status_code not in (400, 403, 405) and r.ok:
+                    size = r.headers.get('content-length')
+                    if size and int(size) > MAX_FILE_SIZE:
+                        h.flash_error('Sorry, this file is too large to be able to display in the browser, please download the data resource to examine it further.')
+            except Exception as e:
+                print(e)
+                h.flash_error('Unable to get resource')
         template = self._resource_template(dataset_type)
         return render(template, extra_vars=vars)
 


### PR DESCRIPTION
Fixes: https://gitlab.com/datopian/core/support/-/issues/306

## Files updated
* [ckanext/opendatani/ontroller.py](https://github.com/datopian/ckanext-opendatani/blob/master/ckanext/opendatani/controller.py)

  * Added a try block to wrap the existing code in the `resource_read` method within the `CustomPackageController` class.
    ```python
            try:
                r = requests.head(c.resource['url'])
                if r.status_code not in (400, 403, 405) and r.ok:
                    size = r.headers.get('content-length')
                    if size and int(size) > MAX_FILE_SIZE:
                        h.flash_error('Sorry, this file is too large to be able to display in the browser, please download the data resource to examine it further.')
            except Exception as e:
                print(e)
                h.flash_error('Unable to get resource')
    ```