### PR TITLE
Fix py3 syntax for dcat profiles and add NISRA profile

### DIFF
--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -334,6 +334,69 @@ class DaeraCoreProfile(RDFProfile):
 
         return dataset_dict
 
+class NisraProfile(RDFProfile):
+
+    def parse_dataset(self, dataset_dict, dataset_ref):
+
+        # TODO: if there is more than one source with different defaults,
+        # modify accordingly
+        dataset_dict['frequency'] = 'notPlanned'
+        dataset_dict['topic_category'] = '-'
+        dataset_dict['lineage'] = 'NISRA'
+        dataset_dict['contact_name'] = 'Christopher O’Neill'
+        dataset_dict['contact_email'] = 'christopher.oneill@nisra.gov.uk'
+        dataset_dict['license_id'] = 'uk-ogl'
+
+        _remove_extra('contact_name', dataset_dict)
+        _remove_extra('contact_email', dataset_dict)
+
+        # Ping the ArcGIS server so the processing of the files
+        # starts
+        identifier = None
+        avoid = []
+
+        if toolkit.asbool(
+                config.get('ckanext.opendatani.harvest.ping_arcgis_urls')):
+
+            for extra in dataset_dict.get('extras', []):
+                if extra['key'] == 'identifier' and extra['value']:
+                    identifier = extra['value']
+            if identifier:
+                query = toolkit.get_action('package_search')(
+                    {}, {'q': 'guid:"{0}"'.format(identifier)})
+                if query['count']:
+                    current_dataset = query['results'][0]
+                    for current_resource in current_dataset.get('resources',
+                                                                []):
+                        if ('requested' in current_resource and
+                                toolkit.asbool(current_resource['requested'])):
+                            avoid.append(current_resource['url'])
+
+            for resource in dataset_dict.get('resources', []):
+                if resource['format'] == 'OGC WMS':
+                    resource['format'] = 'WMS'
+
+                resource['requested'] = False
+                file_formats = ('geojson', 'kml', 'zip', 'csv')
+
+                if resource['url'] in avoid:
+                    resource['requested'] = True
+                elif resource['format'].lower() in file_formats:
+                    try:
+                        requests.head(resource['url'])
+
+                        resource['requested'] = True
+                        log.debug(
+                            'Requested resource to start the processing: {0}'
+                            .format(resource['url']))
+                    except Exception, e:
+                        log.debug(
+                            'Error requesting resource: {0}\n{1}'
+                            .format(resource['url'], e))
+                        pass
+
+        return dataset_dict
+
 
 def _remove_extra(key, dataset_dict):
         dataset_dict['extras'][:] = [e

--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -341,7 +341,7 @@ class NisraProfile(RDFProfile):
         # TODO: if there is more than one source with different defaults,
         # modify accordingly
         dataset_dict['frequency'] = 'notPlanned'
-        dataset_dict['topic_category'] = '-'
+        dataset_dict['topic_category'] = 'location'
         dataset_dict['lineage'] = 'NISRA'
         dataset_dict['contact_name'] = 'Christopher O’Neill'
         dataset_dict['contact_email'] = 'christopher.oneill@nisra.gov.uk'

--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from pylons import config
+from ckan.common import config
 
 from rdflib.namespace import Namespace
 

--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -389,7 +389,7 @@ class NisraProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))

--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -72,7 +72,7 @@ class NIArcGISProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))
@@ -136,7 +136,7 @@ class CausewayProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))
@@ -200,7 +200,7 @@ class MidulsterProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))
@@ -263,7 +263,7 @@ class EsriArcGISProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))
@@ -326,7 +326,7 @@ class DaeraCoreProfile(RDFProfile):
                         log.debug(
                             'Requested resource to start the processing: {0}'
                             .format(resource['url']))
-                    except Exception, e:
+                    except Exception as e:
                         log.debug(
                             'Error requesting resource: {0}\n{1}'
                             .format(resource['url'], e))

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         midulster_profile=ckanext.opendatani.dcat:MidulsterProfile
         esri_arcgis_profile=ckanext.opendatani.dcat:EsriArcGISProfile
         daera_core_profile=ckanext.opendatani.dcat:DaeraCoreProfile
+        nisra_profile=ckanext.opendatani.dcat:NisraProfile
 
     ''',
 )


### PR DESCRIPTION
This PR fixes 
- The config import from pylons (importing from ckan.common now)
- Py2 syntax issues for Exception handling
- Adds a new NISRA profile as per client's requirements.