### PR TITLE
[dcat][xs]: check resource for key format

### DIFF
--- a/ckanext/opendatani/dcat.py
+++ b/ckanext/opendatani/dcat.py
@@ -56,7 +56,7 @@ class NIArcGISProfile(RDFProfile):
                             avoid.append(current_resource['url'])
 
             for resource in dataset_dict.get('resources', []):
-                if resource['format'] == 'OGC WMS':
+                if resource['format'] and resource['format'] == 'OGC WMS':
                     resource['format'] = 'WMS'
 
                 resource['requested'] = False
@@ -64,7 +64,7 @@ class NIArcGISProfile(RDFProfile):
 
                 if resource['url'] in avoid:
                     resource['requested'] = True
-                elif resource['format'].lower() in file_formats:
+                elif resource['format'] and resource['format'].lower() in file_formats:
                     try:
                         requests.head(resource['url'])
 


### PR DESCRIPTION
This is fix for resource format, when source has a null value.
```
{
"@type": "dcat:Distribution",
"title": "Test data",
"format": null,
"accessURL": "https://test.com",
"description": null
}
```
